### PR TITLE
feat(crashlog): cherry-pick log_CrashLog/store_CrashLog hooks

### DIFF
--- a/components/esp_system/panic.c
+++ b/components/esp_system/panic.c
@@ -72,6 +72,17 @@
 bool g_panic_abort = false;
 char *g_panic_abort_details = NULL;
 
+// CrashLog hooks — strong overrides provided by `components/logsink/`. See
+// `docs/logging/crash-log-publisher-plan.md`. log_CrashLog is invoked from
+// panic_print_* sites in panic.c, panic_arch.c, and debug_helpers.c to fan
+// panic-time text into the .noinit log ring. store_CrashLog is invoked
+// after esp_core_dump_write to set the freeze magic. Both have empty weak
+// defaults so projects that don't link logsink still compile.
+extern void log_CrashLog(bool panic, const char *format, ...);
+extern void store_CrashLog(void);
+void __attribute__((weak)) log_CrashLog(bool panic, const char *format, ...) {}
+void __attribute__((weak)) store_CrashLog(void) {}
+
 static wdt_hal_context_t rtc_wdt_ctx = RWDT_HAL_CONTEXT_DEFAULT();
 
 static uint32_t DRAM_ATTR g_panic_entry_count[CONFIG_FREERTOS_NUMBER_OF_CORES] = {0}; // Number of times panic handler has been entered per core since multiple cores can enter the panic handler simultaneously
@@ -173,6 +184,7 @@ void panic_print_dec(int d)
 static void print_abort_details(const void *f)
 {
     panic_print_str(g_panic_abort_details);
+    log_CrashLog(true, "Abort() function called within the program, with these details: %s\n", g_panic_abort_details);
 }
 
 /********************** Panic handler watchdog timer functions **********************/
@@ -327,10 +339,12 @@ void esp_panic_handler(panic_info_t *info)
         panic_print_str(" panic'ed (");
         panic_print_str(info->reason);
         panic_print_str("). ");
+        log_CrashLog(true, "Guru Meditation Error: Core %d panic'ed (%s).\n", info->core, info->reason);
     }
 
     if (info->description) {
         panic_print_str(info->description);
+        log_CrashLog(true, "%s\n", info->description);
     }
 
     panic_print_str("\r\n");
@@ -412,6 +426,12 @@ void esp_panic_handler(panic_info_t *info)
         s_dumping_core = false;
     }
 #endif /* CONFIG_ESP_COREDUMP_ENABLE */
+
+    // Set the .noinit freeze magic so logsink_crash_publish.cpp can detect
+    // and ship the captured ring on the next boot. Runs after coredump so
+    // panic-time DRAM (incl. the ring) is preserved in the binary dump
+    // regardless of whether MQTT publish later succeeds.
+    store_CrashLog();
 
 #if CONFIG_ESP_SYSTEM_PANIC_GDBSTUB
     panic_print_str("Entering gdb stub now.\r\n");

--- a/components/esp_system/port/arch/xtensa/debug_helpers.c
+++ b/components/esp_system/port/arch/xtensa/debug_helpers.c
@@ -57,6 +57,10 @@ static void ESP_SYSTEM_IRAM_ATTR print_str(const char* str, bool panic)
     }
 }
 
+// CrashLog hook — strong override in `components/logsink/`. See
+// `docs/logging/crash-log-publisher-plan.md`.
+extern void log_CrashLog(bool panic, const char *format, ...);
+
 esp_err_t ESP_SYSTEM_IRAM_ATTR esp_backtrace_print_from_frame(int depth, const esp_backtrace_frame_t* frame, bool panic)
 {
     //Check arguments
@@ -70,6 +74,9 @@ esp_err_t ESP_SYSTEM_IRAM_ATTR esp_backtrace_print_from_frame(int depth, const e
 
     print_str("\r\n\r\nBacktrace:", panic);
     print_entry(esp_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp, panic);
+    log_CrashLog(true,
+                 "Backtrace [BT-0|depth=0 => panic location!]: PC(call)=0x%08X, SP(stack)=0x%08X (please refer to original ELF file to locate this exact call instruction address)\n",
+                 esp_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp);
 
     //Check if first frame is valid
     bool corrupted = !(esp_stack_ptr_is_sane(stk_frame.sp) &&
@@ -78,11 +85,16 @@ esp_err_t ESP_SYSTEM_IRAM_ATTR esp_backtrace_print_from_frame(int depth, const e
                         (stk_frame.exc_frame && ((XtExcFrame *)stk_frame.exc_frame)->exccause == EXCCAUSE_INSTR_PROHIBITED)));
 
     uint32_t i = (depth <= 0) ? INT32_MAX : depth;
+    int t = 1;
     while (i-- > 0 && stk_frame.next_pc != 0 && !corrupted) {
         if (!esp_backtrace_get_next_frame(&stk_frame)) {    //Get previous stack frame
             corrupted = true;
         }
         print_entry(esp_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp, panic);
+        log_CrashLog(true,
+                     "Backtrace [BT-%d|depth=+%d]: PC(call)=0x%08X, SP(stack)=0x%08X (please refer to original ELF file to locate this exact call instruction address)\n",
+                     t, t, esp_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp);
+        ++t;
     }
 
     //Print backtrace termination marker

--- a/components/esp_system/port/arch/xtensa/panic_arch.c
+++ b/components/esp_system/port/arch/xtensa/panic_arch.c
@@ -29,6 +29,10 @@
 #endif
 #endif // CONFIG_IDF_TARGET_ESP32
 
+// CrashLog hook — strong override in `components/logsink/`. See
+// `docs/logging/crash-log-publisher-plan.md`.
+extern void log_CrashLog(bool panic, const char *format, ...);
+
 void panic_print_registers(const void *f, int core)
 {
     XtExcFrame *frame = (XtExcFrame *) f;
@@ -60,6 +64,13 @@ void panic_print_registers(const void *f, int core)
         }
     }
 
+    log_CrashLog(true,
+                 "Register Dump from Core %d (1/2): PC=0x%08X, PS=0x%08X, SAR=0x%02X, EXCCAUSE=0x%08X, EXCVADDR=0x%08X, LBEG=0x%08X, LEND=0x%08X, LCOUNT=0x%08X\n",
+                 core, regs[1], regs[2], regs[19], regs[20], regs[21], regs[22], regs[23], regs[24]);
+    log_CrashLog(true,
+                 "Register Dump from Core %d (2/2): A0=0x%08X, A1(SP)=0x%08X, A2=0x%08X, A3=0x%08X, A4=0x%08X, A5=0x%08X, A6=0x%08X, A7=0x%08X, A8=0x%08X, A9=0x%08X, A10=0x%08X, A11=0x%08X, A12=0x%08X, A13=0x%08X, A14=0x%08X, A15=0x%08X\n",
+                 core, regs[3], regs[4], regs[5], regs[6], regs[7], regs[8], regs[9], regs[10], regs[11], regs[12], regs[13], regs[14], regs[15], regs[16], regs[17], regs[18]);
+
     // If the core which triggers the interrupt watchpoint was in ISR context, dump the epc registers.
     if (xPortInterruptedFromISRContext()
 #if !CONFIG_ESP_SYSTEM_SINGLE_CORE_MODE
@@ -90,6 +101,8 @@ void panic_print_registers(const void *f, int core)
         __asm__("rsr.epc4 %0" : "=a"(__value));
         panic_print_str("  EPC4    : 0x");
         panic_print_hex(__value);
+
+        log_CrashLog(true, "Interrupt Context on Core %d: This Core was running in ISR context when the panic occurred.\n", core);
     }
 }
 
@@ -116,6 +129,8 @@ static void print_illegal_instruction_details(const void *f)
     panic_print_hex(*(pepc + 1));
     panic_print_str(" ");
     panic_print_hex(*(pepc + 2));
+
+    log_CrashLog(true, "Illegal OpCode with Memory Dump at 0x%X: %X %X %X\n", epc, *pepc, *(pepc + 1), *(pepc + 2));
 }
 
 static void print_debug_exception_details(const void *f)


### PR DESCRIPTION
## Summary

Cherry-picks the crash-logging hook surface from
[`pulsatrix-emobility/charging-station-controller`](https://github.com/pulsatrix-emobility/charging-station-controller)
commit \`c964d3dae8\`, adapted for IDF v6.0. Adds two weak hooks
(\`log_CrashLog\`, \`store_CrashLog\`) called from inside ESP-IDF's
panic path. User code (in the consuming firmware repo's \`logsink\`
component) provides strong overrides to capture panic-time output
(Guru Meditation banner, register dump, backtrace) into a \`.noinit\`
ring for post-reboot MQTT publish.

Without this patch, the \`.noinit\` ring captures only pre-panic
context — the actual crash trace never reaches it, because
\`panic_print_*\` writes directly to UART and bypasses \`vprintf\`.

## What's changed

13 inserts across 3 files (no functional change with weak defaults
— this is dormant scaffolding until consumers link a strong override):

- \`components/esp_system/panic.c\` (+20): extern decls + weak defaults
  near top; calls in \`print_abort_details\`, the Guru Meditation
  header block, and the \`info->description\` block; \`store_CrashLog()\`
  after \`esp_core_dump_write\`.
- \`components/esp_system/port/arch/xtensa/panic_arch.c\` (+15): extern
  decl, two register-dump halves (PC/PS/SAR/EXCCAUSE/EXCVADDR/LBEG/
  LEND/LCOUNT and A0–A15), ISR-context flag, illegal-opcode dump.
- \`components/esp_system/port/arch/xtensa/debug_helpers.c\` (+12):
  extern decl + BT-0 capture + BT-N loop with depth counter.

## What's NOT in scope

- CSC's edits to \`components/esp_system/port/panic_handler.c\` are
  dev-only \`panic_print_str("Entered ...")\` breadcrumbs; not
  carried over.
- CSC's edits to \`components/log/include/esp_log.h\` (capturing
  \`ESP_EARLY_LOG\` / \`ESP_DRAM_LOG\` via the same hook) are tracked
  as a follow-up — IDF v6.0 restructured these macros with
  \`ESP_LOG_VERSION\` switching, low operational value for the
  primary "backtrace in ring" goal.

## Bugs in CSC's patch fixed during port

- \`panic.c print_abort_details\`: \`%S\` → \`%s\` (wide-string
  specifier was wrong for a \`char*\`).
- \`panic_arch.c print_illegal_instruction_details\`: \`pepc\` → \`*pepc\`
  (was passing the pointer instead of the dereferenced value to a
  \`%X\` specifier).

## Test plan

- [x] \`idf.py build\` clean against a consuming firmware repo
  (\`user-interface-controller\`) with no strong overrides linked —
  weak defaults take over, no link errors, binary builds.
- [x] Diff is exactly the 47-line cherry-pick (no stray changes).
- [ ] Strong override in the consuming firmware's \`logsink\` will be
  tested end-to-end by deliberate \`abort()\` in test firmware (covered
  in the consuming repo's PR sequence).

Companion: this PR is the IDF-side dormant scaffolding. The consuming
firmware's \`logsink\` PR (separate repo) will provide the strong
overrides that actually use these hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)